### PR TITLE
Fix the problem that clicking the logo cannot jump to the home page

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -13,7 +13,7 @@
   <script>
     window.$docsify = {
       name: 'MSL2-Python Document',
-      nameLink:'/',
+      nameLink: document.domain === 'localhost' ? '/':'/MSL2-Python/',
       repo: 'NTFS2020/MSL2-Python',
       logo: 'logo_small.png',
       notFoundPage: true,


### PR DESCRIPTION
修复了跳转首页的问题
在链接为“ http://localhost:xxxx/ ”的时候应该跳转到根目录，才是回首页
而在GitHub Pages中，实际上首页是“ http://ntfs2020.github.io/MSL2-Python ”，但实际上是跳转到“ http://ntfs2020.github.io/ ”
![image](https://user-images.githubusercontent.com/72146468/160737011-20d1777e-6eae-4db1-ab50-7f1617c662e5.png)
也就是说，在“ http://localhost:xxxx/README ”的时候要跳转到“ http://localhost:xxxx/ ”
在“ http://ntfs2020.github.io/MSL2-Pyhton/README ”的时候应该跳转到“ http://ntfs2020.github.io/MSL2-Python/ ”
在代码“index.html”中增加了一个判断
![image](https://user-images.githubusercontent.com/72146468/160737524-6d43bef7-313f-4a81-98a8-c60f8b38d3fd.png)
当domain（域名）为“localhost”时设置主页为根目录，否则设置主页为“domain.xxx/MSL2-Python/”
改完的效果如图：
![image](https://user-images.githubusercontent.com/72146468/160737856-0bc7152d-3712-4e05-bcc6-edab72352f75.png)
![image](https://user-images.githubusercontent.com/72146468/160738054-c3ba6805-0ed8-4746-857a-afda33ad4755.png)
